### PR TITLE
fix(lsp): validator rejects type constructors from loaded prelude

### DIFF
--- a/src/builtins_io.c
+++ b/src/builtins_io.c
@@ -19,6 +19,14 @@ static bool env_has_name(const char *name, void *ctx) {
       if (strcmp(env->symbols.items[i], name) == 0) return true;
     env = env->parent;
   }
+  valk_type_env_t *tenv = valk_type_env_global();
+  if (valk_type_env_find_constructor(tenv, name)) return true;
+  for (u64 i = 0; i < tenv->constructor_count; i++) {
+    const char *full = tenv->constructors[i]->name;
+    const char *sep = strstr(full, "::");
+    if (sep && strcmp(sep + 2, name) == 0) return true;
+  }
+  if (valk_type_env_find_type(tenv, name)) return true;
   return false;
 }
 

--- a/src/lsp-main.valk
+++ b/src/lsp-main.valk
@@ -1,0 +1,7 @@
+(load "src/prelude.valk")
+(load "src/symdb.valk")
+(load "src/lsp-analysis.valk")
+(load "src/lsp-validate.valk")
+(load "src/lsp-hints.valk")
+(load "src/lsp.valk")
+(lsp/main)

--- a/test/test_lsp_parse.valk
+++ b/test/test_lsp_parse.valk
@@ -1,0 +1,47 @@
+(load "src/prelude.valk")
+(load "src/modules/test.valk")
+
+(test/run (list
+  (test "lsp-parses-without-errors"
+    {do
+    (= {text} (read-file "src/lsp.valk"))
+    (test/assert (not (error? text)) "should read lsp.valk")
+    (= {ast} (parse text))
+    (test/assert (not (error? ast)) (str "lsp.valk should parse: " ast))
+    true
+  })
+  (test "lsp-analysis-parses"
+    {do
+    (= {text} (read-file "src/lsp-analysis.valk"))
+    (test/assert (not (error? text)) "should read lsp-analysis.valk")
+    (= {ast} (parse text))
+    (test/assert (not (error? ast)) (str "lsp-analysis.valk should parse: " ast))
+    true
+  })
+  (test "lsp-validate-parses"
+    {do
+    (= {text} (read-file "src/lsp-validate.valk"))
+    (test/assert (not (error? text)) "should read lsp-validate.valk")
+    (= {ast} (parse text))
+    (test/assert (not (error? ast)) (str "lsp-validate.valk should parse: " ast))
+    true
+  })
+  (test "lsp-hints-parses"
+    {do
+    (= {text} (read-file "src/lsp-hints.valk"))
+    (test/assert (not (error? text)) "should read lsp-hints.valk")
+    (= {ast} (parse text))
+    (test/assert (not (error? ast)) (str "lsp-hints.valk should parse: " ast))
+    true
+  })
+  (test "lsp-loads-without-validation-errors"
+    {do
+    (load "src/symdb.valk")
+    (load "src/lsp-analysis.valk")
+    (load "src/lsp-validate.valk")
+    (load "src/lsp-hints.valk")
+    (load "src/lsp.valk")
+    (test/assert (not (nil? lsp/main)) "lsp/main should be defined after load")
+    true
+  })
+))


### PR DESCRIPTION
## Summary

- **`src/builtins_io.c`**: The `load` builtin's validator (`env_has_name`) only checked `lenv` for known symbols, missing type constructors (`None`, `Some`, `Ok`, `Err`) stored in the separate `type_env`. Now checks both qualified (`Option::None`) and short (`None`) constructor names, plus type names.
- **`src/lsp-main.valk`**: New entry point that loads all LSP dependencies (prelude, symdb, analysis, validate, hints) before `lsp.valk`, so they're in the runtime environment when the validator runs on `lsp.valk`.
- **`test/test_lsp_parse.valk`**: Added `lsp-loads-without-validation-errors` test that actually `load`s all LSP files (triggering the validator), catching this class of bug. Existing tests only called `parse` which checks syntax but not symbol resolution.

## Problem

The LSP server failed on startup with ~130 "Function 'X' is not defined" errors because:
1. `lsp.valk` has `(load "src/prelude.valk")` inside it, but the validator runs on the entire file AST *before* evaluating any expressions — so prelude functions aren't in the env yet
2. Even after fixing the load order, type constructors like `None` were stored in `type_env` (not `lenv`), so `env_has_name` never found them